### PR TITLE
printRow([]) changed to :- nl, true.

### DIFF
--- a/nonogram.pl
+++ b/nonogram.pl
@@ -213,7 +213,7 @@ nonogramGen(RowHints, ColHints, F) :-
     maplist(applyConstrain, ColsWithHints)
 .
 
-printRow([]) :- nl, false.
+printRow([]) :- nl, true.
 printRow([black | T]) :- write('◼'), write(' '), printRow(T).
 printRow([white | T]) :- write('◻'), write(' '), printRow(T).
 printRow([_ | T]) :- write('¿'), write(' '), printRow(T).


### PR DESCRIPTION
printNonogram() now works for our first example nonogram as intended (the one you get from nonogram1Gen)
